### PR TITLE
Revert "Bump color-print from 0.3.5 to 0.3.6"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,23 +227,23 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "color-print"
-version = "0.3.6"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee543c60ff3888934877a5671f45494dd27ed4ba25c6670b9a7576b7ed7a8c0"
+checksum = "7a858372ff14bab9b1b30ea504f2a4bc534582aee3e42ba2d41d2a7baba63d5d"
 dependencies = [
  "color-print-proc-macro",
 ]
 
 [[package]]
 name = "color-print-proc-macro"
-version = "0.3.6"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff1a80c5f3cb1ca7c06ffdd71b6a6dd6d8f896c42141fbd43f50ed28dcdb93"
+checksum = "57e37866456a721d0a404439a1adae37a31be4e0055590d053dfe6981e05003f"
 dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.82"
 bzip2 = { version = "0.4.4", features = ["static"] }
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
-color-print = "0.3.6"
+color-print = "0.3.5"
 console = { version = "0.15.8", features = ["windows-console-colors"] }
 hex = "0.4.3"
 indicatif = "0.17.8"


### PR DESCRIPTION
Reverts topminipie/otadump#49